### PR TITLE
Add set setThemeManager() method to the component theme concern

### DIFF
--- a/src/Concerns/HasPath.php
+++ b/src/Concerns/HasPath.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ChatAgency\BackendComponents\Concerns;
 
 use function ChatAgency\BackendComponents\backendComponentNamespace;
+use function ChatAgency\BackendComponents\isBackedEnum;
 
 trait HasPath
 {
@@ -16,6 +17,17 @@ trait HasPath
     private ?string $path = null;
 
     private bool $useLocal = false;
+
+    public function getName(): int|string
+    {
+        $name = $this->name;
+
+        if (isBackedEnum($name)) {
+            return $name->value;
+        }
+
+        return $name;
+    }
 
     public function useLocal(bool $local = true): static
     {

--- a/src/Concerns/IsThemeable.php
+++ b/src/Concerns/IsThemeable.php
@@ -15,6 +15,13 @@ trait IsThemeable
 
     private ThemeManager $themeManager;
 
+    public function setThemeManager(ThemeManager $themeManager): static
+    {
+        $this->themeManager = $themeManager;
+
+        return $this;
+    }
+
     /**
      * @return array<string, string|array<string|int, string>>
      */

--- a/src/Contracts/PathComponent.php
+++ b/src/Contracts/PathComponent.php
@@ -6,6 +6,8 @@ namespace ChatAgency\BackendComponents\Contracts;
 
 interface PathComponent
 {
+    public function getName(): int|string;
+
     public function useLocal(bool $local = true): static;
 
     public function getNamespace(): ?string;

--- a/src/Contracts/ThemeComponent.php
+++ b/src/Contracts/ThemeComponent.php
@@ -6,6 +6,8 @@ namespace ChatAgency\BackendComponents\Contracts;
 
 interface ThemeComponent
 {
+    public function setThemeManager(ThemeManager $themeManager): static;
+
     /**
      * @param  string|array<string|int, string>  $theme
      */

--- a/src/MainBackendComponent.php
+++ b/src/MainBackendComponent.php
@@ -34,17 +34,6 @@ final class MainBackendComponent implements CompoundComponent, Htmlable
         private ThemeManager $themeManager = new DefaultThemeManager
     ) {}
 
-    public function getName(): int|string
-    {
-        $name = $this->name;
-
-        if (isBackedEnum($name)) {
-            return $name->value;
-        }
-
-        return $name;
-    }
-
     public function getAttributeBag(): AttributeBag
     {
         return new DefaultAttributeBag(

--- a/tests/Unit/Components/SimpleComponentTest.php
+++ b/tests/Unit/Components/SimpleComponentTest.php
@@ -7,6 +7,8 @@ namespace Tests\Unit\Components;
 use ChatAgency\BackendComponents\Builders\ComponentBuilder;
 use ChatAgency\BackendComponents\Enums\ComponentEnum;
 use ChatAgency\BackendComponents\MainBackendComponent;
+use ChatAgency\BackendComponents\Themes\DefaultThemeManager;
+use ChatAgency\BackendComponents\Themes\LocalThemeManager;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -169,5 +171,17 @@ class SimpleComponentTest extends TestCase
 
         $this->assertIsArray($componentArray['contents']['span_2']['contents']);
         $this->assertEquals('this is a link', $componentArray['contents']['span_2']['contents'][0]['contents'][0]);
+    }
+
+    #[Test]
+    public function the_theme_manager_can_be_overwritten_after_an_instance_is_created()
+    {
+        $component = new MainBackendComponent('div');
+
+        $this->assertInstanceOf(DefaultThemeManager::class, $component->getThemeManager());
+
+        $component->setThemeManager(new LocalThemeManager);
+
+        $this->assertInstanceOf(LocalThemeManager::class, $component->getThemeManager());
     }
 }


### PR DESCRIPTION
Adds `setThemeManager()` method to the `IsThemeable` concern.

This helps overwriting the theme manager when necessary.

Also moves the `getName()` method from the `MainBackendComponent` class to the `HasPath` concern.